### PR TITLE
fix: use EvmAppOptions in CLI tempApp initialization

### DIFF
--- a/evmd/cmd/evmd/cmd/root.go
+++ b/evmd/cmd/evmd/cmd/root.go
@@ -54,9 +54,9 @@ func NewRootCmd() *cobra.Command {
 	// we "pre"-instantiate the application for getting the injected/configured encoding configuration
 	// and the CLI options for the modules
 	// add keyring to autocli opts
-	noOpEvmAppOptions := func(_ uint64) error {
-		return nil
-	}
+	//
+	// NOTE: We must use config.EvmAppOptions here (not a no-op) because CLI commands
+	// like gentx validate genesis which requires EVM coin info to be configured.
 	tempApp := evmd.NewExampleApp(
 		log.NewNopLogger(),
 		dbm.NewMemDB(),
@@ -64,7 +64,7 @@ func NewRootCmd() *cobra.Command {
 		true,
 		simtestutil.EmptyAppOptions{},
 		config.EVMChainID,
-		noOpEvmAppOptions,
+		config.EvmAppOptions,
 	)
 
 	encodingConfig := sdktestutil.TestEncodingConfig{


### PR DESCRIPTION
## Summary

Fix nil pointer dereference in CLI commands like `gentx` when `GetEVMCoinDecimals()` is called.

The bug was that CLI commands were using a no-op function for `EvmAppOptions`:

```go
noOpEvmAppOptions := func(_ uint64) error {
    return nil
}
```

This meant `config.Configure()` was never called during CLI command execution, leaving `evmCoinInfo` nil. When `gentx` validates genesis, it calls `GetEVMCoinDecimals()` which panics on nil pointer.

## Changes

- Replace `noOpEvmAppOptions` with `config.EvmAppOptions` in `NewRootCmd()` 
- This ensures CLI commands properly initialize EVM coin configuration

## Test plan

- [x] Build evmd binary
- [x] Run `evmd init` followed by `evmd genesis gentx` - no longer panics
- [x] Start chain and produce blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)