### PR TITLE
fix: set default EVM coin info during app initialization

### DIFF
--- a/evmd/app.go
+++ b/evmd/app.go
@@ -214,6 +214,21 @@ func NewExampleApp(
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *EVMD {
 	evmChainID := cast.ToUint64(appOpts.Get(srvflags.EVMChainID))
+
+	// Set default EVM coin info to prevent nil pointer dereferences in CLI commands.
+	// This provides a fallback when evmCoinInfo hasn't been initialized yet (e.g., gentx).
+	if coinInfo, ok := evmconfig.ChainsCoinInfo[evmChainID]; ok {
+		evmtypes.SetDefaultEvmCoinInfo(coinInfo)
+	} else {
+		// Default to 18 decimals configuration
+		evmtypes.SetDefaultEvmCoinInfo(evmtypes.EvmCoinInfo{
+			Denom:         "atest",
+			ExtendedDenom: "atest",
+			DisplayDenom:  "test",
+			Decimals:      evmtypes.EighteenDecimals.Uint32(),
+		})
+	}
+
 	encodingConfig := evmencoding.MakeConfig(evmChainID)
 
 	appCodec := encodingConfig.Codec


### PR DESCRIPTION
## Summary

Builds on top of #3 to complete the CLI nil pointer fix.

PR #3 added the `defaultEvmCoinInfo` fallback mechanism in the types package, but it requires `SetDefaultEvmCoinInfo()` to be called somewhere. For CLI commands like `gentx`, this was never happening because:

1. CLI creates temp app with `simtestutil.EmptyAppOptions{}`
2. `Keeper.WithDefaultEvmCoinInfo()` is never called during CLI execution
3. Both `evmCoinInfo` and `defaultEvmCoinInfo` remain `nil`
4. `GetEVMCoinDecimals()` → `getEvmCoinInfo()` returns `nil` → **panic**

## Solution

Call `evmtypes.SetDefaultEvmCoinInfo()` early in `NewExampleApp` to ensure the fallback is always initialized. This uses the chain-specific config from `evmconfig.ChainsCoinInfo` when available, or falls back to sensible 18-decimal defaults.

## Test plan

- [x] Build evmd binary
- [x] Run `evmd init` followed by `evmd genesis gentx` - no longer panics
- [x] Start chain and produce blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)